### PR TITLE
Add AI filter extension scaffold

### DIFF
--- a/ai-filter/_locales/en-US/messages.json
+++ b/ai-filter/_locales/en-US/messages.json
@@ -1,0 +1,7 @@
+{
+  "classification": {"message": "AI classification…"},
+  "options.title": {"message": "AI Filter Options"},
+  "options.endpoint": {"message": "Endpoint"},
+  "options.system": {"message": "System prompt"},
+  "options.save": {"message": "Save"}
+}

--- a/ai-filter/background.js
+++ b/ai-filter/background.js
@@ -1,0 +1,5 @@
+browser.runtime.onMessage.addListener((msg) => {
+  if (msg && msg.type === "aiFilter:test") {
+    return browser.experiments.aiFilter.classify(msg);
+  }
+});

--- a/ai-filter/experiment/api.js
+++ b/ai-filter/experiment/api.js
@@ -1,0 +1,45 @@
+var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
+var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var { MailServices } = ChromeUtils.import("resource:///modules/MailServices.jsm");
+
+var resProto = Cc["@mozilla.org/network/protocol;1?name=resource"].getService(Ci.nsISubstitutingProtocolHandler);
+
+function registerResourceUrl(extension, namespace) {
+  if (resProto.hasSubstitution(namespace)) return;
+  let uri = Services.io.newURI(".", null, extension.rootURI);
+  resProto.setSubstitutionWithFlags(namespace, uri, resProto.ALLOW_CONTENT_ACCESS);
+}
+
+var gTerm;
+
+var aiFilter = class extends ExtensionCommon.ExtensionAPI {
+  async onStartup() {
+    let { extension } = this;
+    registerResourceUrl(extension, "aifilter");
+    await extension.storage.local.get(["endpoint", "system"]).then(store => {
+      if (store.endpoint) gEndpoint = store.endpoint;
+      if (store.system) gSystemPrompt = store.system;
+    });
+    ChromeUtils.import("resource://aifilter/modules/ExpressionSearchFilter.jsm");
+  }
+
+  onShutdown(isAppShutdown) {
+    if (!isAppShutdown && resProto.hasSubstitution("aifilter")) {
+      resProto.setSubstitution("aifilter", null);
+    }
+  }
+
+  getAPI(context) {
+    return {
+      aiFilter: {
+        classify: async (msg) => {
+          if (!gTerm) {
+            let mod = ChromeUtils.import("resource://aifilter/modules/ExpressionSearchFilter.jsm");
+            gTerm = new mod.ClassificationTerm();
+          }
+          return gTerm.match(msg.msgHdr, msg.value, Ci.nsMsgSearchOp.Contains);
+        }
+      }
+    };
+  }
+};

--- a/ai-filter/experiment/schema.json
+++ b/ai-filter/experiment/schema.json
@@ -1,0 +1,15 @@
+[
+  {
+    "namespace": "aiFilter",
+    "functions": [
+      {
+        "name": "classify",
+        "type": "function",
+        "async": true,
+        "parameters": [
+          {"name": "msg", "type": "any"}
+        ]
+      }
+    ]
+  }
+]

--- a/ai-filter/manifest.json
+++ b/ai-filter/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 2,
+  "name": "AI Filter",
+  "version": "0.1",
+  "applications": {"gecko": {"id": "ai-filter@example"}},
+  "background": {"scripts": ["background.js"]},
+  "experiment_apis": {
+    "aiFilter": {
+      "schema": "experiment/schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "paths": [["aiFilter"]],
+        "script": "experiment/api.js",
+        "events": ["startup"]
+      }
+    }
+  },
+  "options_ui": {"page": "options.html", "open_in_tab": true},
+  "permissions": ["storage"]
+}

--- a/ai-filter/modules/ExpressionSearchFilter.jsm
+++ b/ai-filter/modules/ExpressionSearchFilter.jsm
@@ -1,0 +1,74 @@
+"use strict";
+var { ExtensionParent } = ChromeUtils.import("resource://gre/modules/ExtensionParent.jsm");
+var { MailServices } = ChromeUtils.import("resource:///modules/MailServices.jsm");
+var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var { NetUtil } = ChromeUtils.import("resource://gre/modules/NetUtil.jsm");
+var { MimeParser } = ChromeUtils.import("resource:///modules/mimeParser.jsm");
+
+var EXPORTED_SYMBOLS = ["AIFilter", "ClassificationTerm"];
+
+class CustomerTermBase {
+  constructor(nameId, operators) {
+    this.extension = ExtensionParent.GlobalManager.getExtension("ai-filter@example");
+    this.id = "aifilter#" + nameId;
+    this.name = this.extension.localeData.localizeMessage(nameId);
+    this.operators = operators;
+    this.cache = new Map();
+  }
+  getEnabled() { return true; }
+  getAvailable() { return true; }
+  getAvailableOperators() { return this.operators; }
+}
+
+function getPlainText(msgHdr) {
+  let folder = msgHdr.folder;
+  if (!folder.getMsgInputStream) return "";
+  let reusable = {};
+  let stream = folder.getMsgInputStream(msgHdr, reusable);
+  let data = NetUtil.readInputStreamToString(stream, msgHdr.messageSize);
+  if (!reusable.value) stream.close();
+  let parser = Cc["@mozilla.org/parserutils;1"].getService(Ci.nsIParserUtils);
+  return parser.convertToPlainText(data,
+    Ci.nsIDocumentEncoder.OutputLFLineBreak |
+    Ci.nsIDocumentEncoder.OutputNoScriptContent |
+    Ci.nsIDocumentEncoder.OutputNoFramesContent |
+    Ci.nsIDocumentEncoder.OutputBodyOnly, 0);
+}
+
+let gEndpoint = "http://127.0.0.1:5000/v1/classify";
+let gSystemPrompt = "[SYSTEM] You are the mail-classification engine.";
+
+class ClassificationTerm extends CustomerTermBase {
+  constructor() { super("classification", [Ci.nsMsgSearchOp.Contains]); }
+
+  match(msgHdr, value, op) {
+    let key = msgHdr.messageId + "|" + value;
+    if (this.cache.has(key)) return this.cache.get(key);
+    let body = getPlainText(msgHdr);
+    let payload = JSON.stringify({
+      prompt: `${gSystemPrompt}\n[CRITERION] «${value}»\n[EMAIL] «${body}»`
+    });
+    let xhr = Cc["@mozilla.org/xmlextras/xmlhttprequest;1"].createInstance(Ci.nsIXMLHttpRequest);
+    xhr.open("POST", gEndpoint, false);
+    xhr.setRequestHeader("Content-Type", "application/json");
+    try { xhr.send(payload); } catch (e) { }
+    let matched = false;
+    if (xhr.status == 200) {
+      try { matched = JSON.parse(xhr.responseText).match === true; } catch (e) {}
+    }
+    this.cache.set(key, matched);
+    return matched;
+  }
+}
+
+(function register() {
+  let term = new ClassificationTerm();
+  if (!MailServices.filters.getCustomTerm(term.id)) {
+    MailServices.filters.addCustomTerm(term);
+  }
+})();
+
+var AIFilter = {};
+
+// allow other modules to access the term
+AIFilter.ClassificationTerm = ClassificationTerm;

--- a/ai-filter/options.html
+++ b/ai-filter/options.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>AI Filter Options</title>
+</head>
+<body>
+  <label>Endpoint: <input id="endpoint" type="text"></label><br>
+  <label>System prompt:<br>
+    <textarea id="system" rows="4" cols="60"></textarea>
+  </label><br>
+  <button id="save">Save</button>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/ai-filter/options.js
+++ b/ai-filter/options.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  let {endpoint = 'http://127.0.0.1:5000/v1/classify', system = '[SYSTEM] You are the mail-classification engine.'} = await browser.storage.local.get(['endpoint','system']);
+  document.getElementById('endpoint').value = endpoint;
+  document.getElementById('system').value = system;
+});
+
+document.getElementById('save').addEventListener('click', async () => {
+  await browser.storage.local.set({
+    endpoint: document.getElementById('endpoint').value,
+    system: document.getElementById('system').value
+  });
+});

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")"
+zip -r extension.xpi _locales api html modules scripts skin ex-background.js manifest.json ai-filter > /dev/null
+echo "Created extension.xpi"


### PR DESCRIPTION
## Summary
- add new ai-filter extension with custom classification term
- provide experimental API and options page
- provide packaging build script

## Testing
- `bash build.sh`

------
https://chatgpt.com/codex/tasks/task_e_684cdc9e1f9c832fba9667cf59a508ac