### PR TITLE
Fix Thunderbird storage retrieval in ai-filter

### DIFF
--- a/ai-filter/background.js
+++ b/ai-filter/background.js
@@ -12,6 +12,15 @@
 
 // Startup
 console.log("[ai-filter] background.js loaded – ready to classify");
+(async () => {
+    try {
+        const store = await browser.storage.local.get(["endpoint", "system"]);
+        await browser.experiments.aiFilter.initConfig(store);
+        console.log("[ai-filter] configuration loaded", store);
+    } catch (err) {
+        console.error("[ai-filter] failed to load config:", err);
+    }
+})();
 
 // Listen for messages from UI/devtools
 browser.runtime.onMessage.addListener(async (msg) => {

--- a/ai-filter/experiment/schema.json
+++ b/ai-filter/experiment/schema.json
@@ -3,6 +3,14 @@
     "namespace": "aiFilter",
     "functions": [
       {
+        "name": "initConfig",
+        "type": "function",
+        "async": true,
+        "parameters": [
+          { "name": "config", "type": "any" }
+        ]
+      },
+      {
         "name": "classify",
         "type": "function",
         "async": true,

--- a/ai-filter/modules/ExpressionSearchFilter.jsm
+++ b/ai-filter/modules/ExpressionSearchFilter.jsm
@@ -38,6 +38,15 @@ function getPlainText(msgHdr) {
 let gEndpoint = "http://127.0.0.1:5000/v1/classify";
 let gSystemPrompt = "[SYSTEM] You are the mail-classification engine.";
 
+function setConfig({ endpoint, system } = {}) {
+  if (endpoint) {
+    gEndpoint = endpoint;
+  }
+  if (system) {
+    gSystemPrompt = system;
+  }
+}
+
 class ClassificationTerm extends CustomerTermBase {
   constructor() { super("classification", [Ci.nsMsgSearchOp.Contains]); }
 
@@ -46,7 +55,7 @@ class ClassificationTerm extends CustomerTermBase {
     if (this.cache.has(key)) return this.cache.get(key);
     let body = getPlainText(msgHdr);
     let payload = JSON.stringify({
-      prompt: `${gSystemPrompt}\n[CRITERION] «${value}»\n[EMAIL] «${body}»`
+      prompt: `${gSystemPrompt}\n[CRITERION] Â«${value}Â»\n[EMAIL] Â«${body}Â»`
     });
     let xhr = Cc["@mozilla.org/xmlextras/xmlhttprequest;1"].createInstance(Ci.nsIXMLHttpRequest);
     xhr.open("POST", gEndpoint, false);
@@ -72,3 +81,4 @@ var AIFilter = {};
 
 // allow other modules to access the term
 AIFilter.ClassificationTerm = ClassificationTerm;
+AIFilter.setConfig = setConfig;


### PR DESCRIPTION
## Summary
- set config from background via new `initConfig` API
- update custom experiment to import filter module and apply config
- expose `setConfig` helper in `ExpressionSearchFilter.jsm`
- load config from storage on background startup

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d2289e34c832f964585bc23321ede