### PR TITLE
Update AI classification filter UI and logic

### DIFF
--- a/ai-filter/_locales/en-US/messages.json
+++ b/ai-filter/_locales/en-US/messages.json
@@ -1,5 +1,7 @@
 {
   "classification": { "message": "AI classification" },
+  "matches": { "message": "matches" },
+  "doesntMatch": { "message": "doesn't match" },
   "options.title": { "message": "AI Filter Options" },
   "options.endpoint": { "message": "Endpoint" },
   "options.system": { "message": "System prompt" },


### PR DESCRIPTION
## Summary
- support `Matches` and `Doesn't match` operators in the AI classifier
- add expectation flag and negate logic
- expose operator strings in locale resources

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684de3af3b4c832f805812bb472ab450