### PR TITLE
Add textbox support for AI classification filter

### DIFF
--- a/ai-filter/background.js
+++ b/ai-filter/background.js
@@ -17,6 +17,15 @@ console.log("[ai-filter] background.js loaded – ready to classify");
         const store = await browser.storage.local.get(["endpoint"]);
         await browser.aiFilter.initConfig(store);
         console.log("[ai-filter] configuration loaded", store);
+        try {
+            await browser.DomContentScript.registerWindow(
+                "chrome://messenger/content/FilterEditor.xhtml",
+                "chrome://aifilter/content/filterEditor.js"
+            );
+            console.log("[ai-filter] registered FilterEditor content script");
+        } catch (e) {
+            console.error("[ai-filter] failed to register content script", e);
+        }
     } catch (err) {
         console.error("[ai-filter] failed to load config:", err);
     }

--- a/ai-filter/content/filterEditor.js
+++ b/ai-filter/content/filterEditor.js
@@ -1,0 +1,50 @@
+(function() {
+  function patch(container) {
+    if (!container || container.getAttribute("ai-filter-patched") === "true") {
+      return;
+    }
+    while (container.firstChild) {
+      container.firstChild.remove();
+    }
+    let frag = window.MozXULElement.parseXULToFragment(
+      `<html:input class="search-value-textbox flexinput ai-filter-textbox" inherits="disabled"
+        onchange="this.parentNode.setAttribute('value', this.value); this.parentNode.value=this.value;">
+      </html:input>`
+    );
+    container.appendChild(frag);
+    if (container.hasAttribute("value")) {
+      container.firstChild.value = container.getAttribute("value");
+    }
+    container.classList.add("flexelementcontainer");
+    container.setAttribute("ai-filter-patched", "true");
+  }
+
+  function check(node) {
+    if (!(node instanceof Element)) {
+      return;
+    }
+    if (
+      node.classList.contains("search-value-custom") &&
+      node.getAttribute("searchAttribute") === "aifilter#classification"
+    ) {
+      patch(node);
+    }
+    node
+      .querySelectorAll('.search-value-custom[searchAttribute="aifilter#classification"]')
+      .forEach(patch);
+  }
+
+  const observer = new MutationObserver(mutations => {
+    for (let mutation of mutations) {
+      if (mutation.type === "childList") {
+        mutation.addedNodes.forEach(check);
+      } else if (mutation.type === "attributes") {
+        check(mutation.target);
+      }
+    }
+  });
+
+  const termList = document.getElementById("searchTermList") || document;
+  observer.observe(termList, { childList: true, attributes: true, subtree: true });
+  check(termList);
+})();

--- a/ai-filter/experiment/DomContentScript/implementation.js
+++ b/ai-filter/experiment/DomContentScript/implementation.js
@@ -1,0 +1,80 @@
+
+
+var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
+var DomContent_ESM = parseInt(AppConstants.MOZ_APP_VERSION, 10) >= 128;
+
+var { ExtensionCommon } = ChromeUtils.importESModule(
+  "resource://gre/modules/ExtensionCommon.sys.mjs"
+);
+
+var { ExtensionUtils } = DomContent_ESM
+  ? ChromeUtils.importESModule("resource://gre/modules/ExtensionUtils.sys.mjs")
+  : ChromeUtils.import("resource://gre/modules/ExtensionUtils.jsm");
+
+var { ExtensionError } = ExtensionUtils;
+
+var registeredWindows = new Map();
+
+var DomContentScript = class extends ExtensionCommon.ExtensionAPI {
+  constructor(extension) {
+    super(extension);
+    
+    this._windowListener = {
+      // nsIWindowMediatorListener functions
+      onOpenWindow(appWindow) {
+        // A new window has opened.
+        let domWindow = appWindow.docShell.domWindow;
+
+        /**
+         * Set up listeners to run the callbacks on the given window.
+         *
+         * @param aWindow {nsIDOMWindow}  The window to set up.
+         * @param aID {String} Optional.  ID of the new caller that has registered right now.
+         */
+        domWindow.addEventListener(
+          "DOMContentLoaded",
+          function() {
+            // do stuff
+            let windowChromeURL = domWindow.document.location.href;
+            if (registeredWindows.has(windowChromeURL)) {
+              let jsPath = registeredWindows.get(windowChromeURL);
+              Services.scriptloader.loadSubScript(jsPath, domWindow, "UTF-8");
+            }
+          },
+          { once: true }
+        );
+      },
+
+      onCloseWindow(appWindow) {
+        // One of the windows has closed.
+        let domWindow = appWindow.docShell.domWindow; // we don't need to do anything (script only loads once)
+      },
+    };
+   
+    Services.wm.addListener(this._windowListener);
+   
+  }
+  
+
+
+
+  
+  onShutdown(isAppShutdown) {
+    if (isAppShutdown) {
+      return; // the application gets unloaded anyway
+    }
+    Services.wm.removeListener(this._windowListener);
+  } 
+  
+  getAPI(context) {
+    /** API IMPLEMENTATION **/
+    return {
+      DomContentScript: {
+        // only returns something, if a user pref value is set
+        registerWindow: async function (windowUrl,jsPath) {
+          registeredWindows.set(windowUrl,jsPath);
+        }
+      },
+    };
+  }
+};

--- a/ai-filter/experiment/DomContentScript/schema.json
+++ b/ai-filter/experiment/DomContentScript/schema.json
@@ -1,0 +1,25 @@
+[
+  {
+    "namespace": "DomContentScript",
+    "functions": [
+      {
+        "name": "registerWindow",
+        "type": "function",
+        "async": true,
+        "description": "Register a script for onDOMContentLoaded",
+        "parameters": [
+          {
+            "name": "windowUrl",
+            "type": "string",
+            "description": "chrome URL of the window "
+          },
+          {
+            "name": "jsPath",
+            "type": "string",
+            "description": "chrome URL of the script"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/ai-filter/manifest.json
+++ b/ai-filter/manifest.json
@@ -14,6 +14,14 @@
         "script": "experiment/api.js",
         "events": [ "startup" ]
       }
+    },
+    "DomContentScript": {
+      "schema": "experiment/DomContentScript/schema.json",
+      "parent": {
+        "scopes": [ "addon_parent" ],
+        "paths": [ [ "DomContentScript" ] ],
+        "script": "experiment/DomContentScript/implementation.js"
+      }
     }
   },
   "options_ui": {


### PR DESCRIPTION
## Summary
- add `DomContentScript` experiment to load DOM scripts
- register content script in background to patch the filter editor
- inject textbox for the `AI classification` custom term

## Testing
- `npm test` *(fails: `package.json` missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e279d5114832faebc42cbf2be312f