### PR TITLE
Rewrite match() to use fetch

### DIFF
--- a/ai-filter/experiment/api.js
+++ b/ai-filter/experiment/api.js
@@ -70,7 +70,7 @@ var aiFilter = class extends ExtensionCommon.ExtensionAPI {
                             gTerm = new mod.ClassificationTerm();
                         }
                         console.log("[ai-filter][api] calling gTerm.match()");
-                        let matchResult = gTerm.match(
+                        let matchResult = await gTerm.match(
                             msg.msgHdr,
                             msg.value,
                             Ci.nsMsgSearchOp.Contains


### PR DESCRIPTION
## Summary
- use `fetch` in `ClassificationTerm.match` instead of synchronous XHR
- await the new async `match` call when using the custom API

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684e5170facc832fa09f0a844ffa97e4