### PR TITLE
Make classification synchronous

### DIFF
--- a/ai-filter/background.js
+++ b/ai-filter/background.js
@@ -32,7 +32,7 @@ console.log("[ai-filter] background.js loaded – ready to classify");
 })();
 
 // Listen for messages from UI/devtools
-browser.runtime.onMessage.addListener(async (msg) => {
+browser.runtime.onMessage.addListener((msg) => {
     console.log("[ai-filter] onMessage received:", msg);
 
     if (msg?.type === "aiFilter:test") {
@@ -42,7 +42,7 @@ browser.runtime.onMessage.addListener(async (msg) => {
 
         try {
             console.log("[ai-filter] Calling browser.aiFilter.classify()");
-            const result = await browser.aiFilter.classify(text, criterion);
+            const result = browser.aiFilter.classify(text, criterion);
             console.log("[ai-filter] classify() returned:", result);
             return { match: result };
         }

--- a/ai-filter/experiment/api.js
+++ b/ai-filter/experiment/api.js
@@ -61,7 +61,7 @@ var aiFilter = class extends ExtensionCommon.ExtensionAPI {
                         console.error("[ai-filter][api] failed to apply config:", err);
                     }
                 },
-                classify: async (msg) => {
+                classify: (msg) => {
                     console.log("[ai-filter][api] classify() called with msg:", msg);
                     try {
                         if (!gTerm) {
@@ -70,7 +70,7 @@ var aiFilter = class extends ExtensionCommon.ExtensionAPI {
                             gTerm = new mod.ClassificationTerm();
                         }
                         console.log("[ai-filter][api] calling gTerm.match()");
-                        let matchResult = await gTerm.match(
+                        let matchResult = gTerm.match(
                             msg.msgHdr,
                             msg.value,
                             Ci.nsMsgSearchOp.Contains

--- a/ai-filter/experiment/schema.json
+++ b/ai-filter/experiment/schema.json
@@ -13,7 +13,6 @@
       {
         "name": "classify",
         "type": "function",
-        "async": true,
         "parameters": [
           {
             "name": "msg",

--- a/ai-filter/modules/ExpressionSearchFilter.jsm
+++ b/ai-filter/modules/ExpressionSearchFilter.jsm
@@ -97,7 +97,7 @@ class ClassificationTerm extends CustomerTermBase {
 
   needsBody() { return true; }
 
-  async match(msgHdr, value, op) {
+  match(msgHdr, value, op) {
     const opName = op === Ci.nsMsgSearchOp.Matches ? "matches" :
                    op === Ci.nsMsgSearchOp.DoesntMatch ? "doesn't match" : `unknown (${op})`;
     console.log(`[ai-filter][ExpressionSearchFilter] Matching message ${msgHdr.messageId} using op "${opName}" and value "${value}"`);
@@ -129,16 +129,15 @@ class ClassificationTerm extends CustomerTermBase {
 
     let matched = false;
     try {
-      const res = await fetch(gEndpoint, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: payload
-      });
+      let xhr = new XMLHttpRequest();
+      xhr.open("POST", gEndpoint, false); // synchronous request
+      xhr.setRequestHeader("Content-Type", "application/json");
+      xhr.send(payload);
 
-      if (!res.ok) {
-        console.warn(`[ai-filter][ExpressionSearchFilter] HTTP status ${res.status}`);
+      if (xhr.status < 200 || xhr.status >= 300) {
+        console.warn(`[ai-filter][ExpressionSearchFilter] HTTP status ${xhr.status}`);
       } else {
-        const result = await res.json();
+        const result = JSON.parse(xhr.responseText);
         const rawText = result.choices?.[0]?.text || "";
         const cleanedText = rawText.replace(/<think>[\s\S]*?<\/think>/gi, "").trim();
         const obj = JSON.parse(cleanedText);


### PR DESCRIPTION
## Summary
- use synchronous XHR inside `ClassificationTerm.match`
- update experiment API to call the new sync method
- remove `async` flag for `classify` in schema
- adjust background page to use the sync API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e877dbe14832fbce810b6abcb9a47